### PR TITLE
Changed tonapi to tonviewer

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -45,7 +45,7 @@ Flags:
 --all - builds all buildable contracts instead of just one.`,
     test: `Usage: blueprint test
 
-Just run \`npm test\`, which by default runs \`jest\`.`,
+Just runs \`npm test\`, which by default runs \`jest\`.`,
 };
 
 export const help: Runner = async (args: Args, ui: UIProvider) => {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -34,7 +34,7 @@ Script name is matched (ignoring case) to a file in the scripts directory. If no
 Flags:
 --mainnet, --testnet - specifies the network to use when running the script. If not specified on the command line, it will be asked interactively.
 --tonconnect, --tonhub, --deeplink, --mnemonic - specifies the deployer to use when running the script. If not specified on the command line, it will be asked interactively.
---tonscan, --tonapi, --toncx, --dton - specifies the network explorer to use when displaying links to the deployed contracts. Default: tonscan.`,
+--tonscan, --tonviewer, --toncx, --dton - specifies the network explorer to use when displaying links to the deployed contracts. Default: tonscan.`,
     build: `Usage: blueprint build [contract name] [flags]
 
 Builds the specified contract according to the respective .compile.ts file. If the contract is written in TACT, all TACT-generated files (wrapper class, etc) will be placed in the build/<contract name> folder.
@@ -45,7 +45,7 @@ Flags:
 --all - builds all buildable contracts instead of just one.`,
     test: `Usage: blueprint test
 
-Just runs \`npm test\`, which by default runs \`jest\`.`,
+Just run \`npm test\`, which by default runs \`jest\`.`,
 };
 
 export const help: Runner = async (args: Args, ui: UIProvider) => {

--- a/src/network/createNetworkProvider.ts
+++ b/src/network/createNetworkProvider.ts
@@ -38,7 +38,7 @@ const argSpec = {
     '--mnemonic': Boolean,
 
     '--tonscan': Boolean,
-    '--tonapi': Boolean,
+    '--tonviewer': Boolean,
     '--toncx': Boolean,
     '--dton': Boolean,
 };
@@ -47,7 +47,7 @@ type Args = arg.Result<typeof argSpec>;
 
 type Network = 'mainnet' | 'testnet';
 
-type Explorer = 'tonscan' | 'tonapi' | 'toncx' | 'dton';
+type Explorer = 'tonscan' | 'tonviewer' | 'toncx' | 'dton';
 
 class SendProviderSender implements Sender {
     #provider: SendProvider;
@@ -138,7 +138,7 @@ class NetworkProviderImpl implements NetworkProvider {
         return this.#network;
     }
 
-    explorer(): 'tonscan' | 'tonapi' | 'toncx' | 'dton' {
+    explorer(): 'tonscan' | 'tonviewer' | 'toncx' | 'dton' {
         return this.#explorer;
     }
 
@@ -261,7 +261,7 @@ class NetworkProviderBuilder {
         return (
             oneOrZeroOf({
                 tonscan: this.args['--tonscan'],
-                tonapi: this.args['--tonapi'],
+                tonviewer: this.args['--tonviewer'],
                 toncx: this.args['--toncx'],
                 dton: this.args['--dton'],
             }) ?? 'tonscan'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,8 +102,8 @@ export function getExplorerLink(address: string, network: string, explorer: stri
         case 'tonscan':
             return `https://${networkPrefix}tonscan.org/address/${address}`;
 
-        case 'tonapi':
-            return `https://${networkPrefix}tonapi.io/account/${address}`;
+        case 'tonviewer':
+            return `https://${networkPrefix}tonviewer.com/${address}`;
 
         case 'toncx':
             return `https://${networkPrefix}ton.cx/address/${address}`;


### PR DESCRIPTION
**Deleted tonapi as explorer, added tonviewer.**

This is needed since this: _https://tonapi.io/account/EQAlIDtPdzqWf2xjELmqVVrNqoGoffoKOGqd4ttqjzyPGWYu_, redirects to that -> _https://tonviewer.com/EQAlIDtPdzqWf2xjELmqVVrNqoGoffoKOGqd4ttqjzyPGWYu_

Changed it in flags, help messages, types. (everywhere)