### PR TITLE
feat: tact compiler options support

### DIFF
--- a/src/compile/CompilerConfig.ts
+++ b/src/compile/CompilerConfig.ts
@@ -9,6 +9,14 @@ export type CommonCompilerConfig = {
 export type TactCompilerConfig = {
     lang: 'tact';
     target: string;
+    options?: {
+        debug?: boolean;
+        masterchain?: boolean;
+        external?: boolean;
+        experimental?: {
+            inline?: boolean;
+        };
+    };
 };
 
 export type FuncCompilerConfig = {

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -63,6 +63,7 @@ async function doCompileTact(config: TactCompilerConfig, name: string): Promise<
             name: 'tact',
             path: path.join(process.cwd(), config.target),
             output: path.join(BUILD_DIR, name),
+            options: config.options,
         },
         stdlib: '/stdlib',
         project: fs,


### PR DESCRIPTION
This PR introduce tact compiler options support. It can come handy in many situations like debugging for example. 