### PR TITLE
feat: add precompile params

### DIFF
--- a/src/compile/CompilerConfig.ts
+++ b/src/compile/CompilerConfig.ts
@@ -3,7 +3,7 @@ import { Cell } from '@ton/core';
 import { ConfigProject } from '@tact-lang/compiler';
 
 export type CommonCompilerConfig = {
-    preCompileHook?: () => Promise<void>;
+    preCompileHook?: (params?: any) => Promise<void>;
     postCompileHook?: (code: Cell) => Promise<void>;
 };
 

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -96,11 +96,11 @@ async function doCompileInner(name: string, config: CompilerConfig): Promise<Com
     } as FuncCompilerConfig);
 }
 
-export async function doCompile(name: string): Promise<CompileResult> {
+export async function doCompile(name: string, precompileParams?: any): Promise<CompileResult> {
     const config = await getCompilerConfigForContract(name);
 
     if (config.preCompileHook !== undefined) {
-        await config.preCompileHook();
+        await config.preCompileHook(precompileParams);
     }
 
     const res = await doCompileInner(name, config);
@@ -112,8 +112,8 @@ export async function doCompile(name: string): Promise<CompileResult> {
     return res;
 }
 
-export async function compile(name: string): Promise<Cell> {
-    const result = await doCompile(name);
+export async function compile(name: string, precompileParams?: any): Promise<Cell> {
+    const result = await doCompile(name, precompileParams);
 
     return result.code;
 }


### PR DESCRIPTION
This PR adds precompile params. 
Right now there is no way to pass any parameters for the pre-compile stage. At the same time, it can be quite useful. For example, it allows to customize auto-generation of func/tact files to programmatically move the "data" part directly into the "code" part of the smart contract.