### PR TITLE
Improve verify

### DIFF
--- a/src/cli/verify.ts
+++ b/src/cli/verify.ts
@@ -229,6 +229,7 @@ export const verify: Runner = async (args: Args, ui: UIProvider) => {
             body: JSON.stringify({
                 messageCell: msgCell,
             }),
+            headers: {'Content-Type': 'application/json'}
         });
 
         if (signResponse.status !== 200) {

--- a/src/cli/verify.ts
+++ b/src/cli/verify.ts
@@ -116,7 +116,7 @@ export const verify: Runner = async (args: Args, ui: UIProvider) => {
         throw new Error('Cannot use custom network');
     }
 
-    const addr = await ui.input('Deployed contract address');
+    const addr = (await ui.inputAddress('Deployed contract address:')).toString();;
 
     const result = await doCompile(sel.name);
 

--- a/src/ui/InquirerUIProvider.ts
+++ b/src/ui/InquirerUIProvider.ts
@@ -29,16 +29,15 @@ export class InquirerUIProvider implements UIProvider {
     }
 
     async inputAddress(message: string, fallback?: Address) {
-        let promptFallback = fallback ? message.replace(/:$/,'') + `(default:${fallback}):` : message;
-        do {
-            let testAddr = (await this.input(promptFallback)).replace(/^\s+|\s+$/g,'');
-            try{
-                return testAddr == "" && fallback ? fallback : Address.parse(testAddr);
+        const prompt = message + (fallback === undefined ? '' : ` (default: ${fallback})`);
+        while (true) {
+            const addr = (await this.input(prompt)).trim();
+            try {
+                return addr === '' && fallback !== undefined ? fallback : Address.parse(addr);
+            } catch (e) {
+                this.write(addr + ' is not valid!\n');
             }
-            catch(e) {
-                this.write(testAddr + " is not valid!\n");
-            }
-        } while(true);
+        }
     }
 
     async input(message: string): Promise<string> {

--- a/src/ui/InquirerUIProvider.ts
+++ b/src/ui/InquirerUIProvider.ts
@@ -1,5 +1,6 @@
 import inquirer from 'inquirer';
 import { UIProvider } from '../ui/UIProvider';
+import { Address } from '@ton/core';
 
 class DestroyableBottomBar extends inquirer.ui.BottomBar {
     destroy() {
@@ -25,6 +26,19 @@ export class InquirerUIProvider implements UIProvider {
             message,
         });
         return prompt;
+    }
+
+    async inputAddress(message: string, fallback?: Address) {
+        let promptFallback = fallback ? message.replace(/:$/,'') + `(default:${fallback}):` : message;
+        do {
+            let testAddr = (await this.input(promptFallback)).replace(/^\s+|\s+$/g,'');
+            try{
+                return testAddr == "" && fallback ? fallback : Address.parse(testAddr);
+            }
+            catch(e) {
+                this.write(testAddr + " is not valid!\n");
+            }
+        } while(true);
     }
 
     async input(message: string): Promise<string> {

--- a/src/ui/UIProvider.ts
+++ b/src/ui/UIProvider.ts
@@ -1,6 +1,9 @@
+import { Address } from '@ton/core';
+
 export interface UIProvider {
     write(message: string): void;
     prompt(message: string): Promise<boolean>;
+    inputAddress(message: string, fallback?: Address): Promise<Address>;
     input(message: string): Promise<string>;
     choose<T>(message: string, choices: T[], display: (v: T) => string): Promise<T>;
     setActionPrompt(message: string): void;


### PR DESCRIPTION
# Improvements

- Fix missing `Content-Type` header in sign request.
- Added input address verification. Before it was possible to pass arbitrary string leading to failure at request time.
-  Now it is possible to query graphql api instead of having to manually enter contract address (optional)
- Better(IMHO) error/info reporting