### PR TITLE
feat: Auto-sourcing of `tact.config.json` if it's present and updating Tact to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added auto-sourcing of root `tact.config.json` files for merging compilation options with `wrappers/*.compile.ts`
+
+### Changed
+
+- Changed `@tact-lang/compiler` dependency to be `^1.3.0` instead of `^1.2.0`
+
 ## [0.19.0] - 2024-03-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added auto-sourcing of root `tact.config.json` files for merging compilation options with `wrappers/*.compile.ts`
+- Added a warning for disabling `debug` in contract wrappers of Tact before doing production deployments
 
 ### Changed
 
 - Changed `@tact-lang/compiler` dependency to be `^1.3.0` instead of `^1.2.0`
+- Changed `compile.ts.template` template for Tact to have `debug` set to `true` by default
+- Changed `contract.tact.template` empty template for Tact to mention implicit empty `init()` function
 
 ## [0.19.1] - 2024-04-12
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm create ton@latest
 ### Requirements
 
 * [Node.js](https://nodejs.org) with a recent version like v18, verify version with `node -v`
-* IDE with TypeScript and FunC support like [Visual Studio Code](https://code.visualstudio.com/) with the [FunC plugin](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode) or [IntelliJ Idea](https://www.jetbrains.com/idea/) with the [TON Development plugin](https://plugins.jetbrains.com/plugin/18541-ton-development)
+* IDE with TypeScript and FunC support like [Visual Studio Code](https://code.visualstudio.com/) with the [FunC plugin](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode) or [IntelliJ IDEA](https://www.jetbrains.com/idea/) with the [TON Development plugin](https://plugins.jetbrains.com/plugin/23382-ton)
 
 &nbsp;
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "dependencies": {
         "@orbs-network/ton-access": "^2.3.3",
-        "@tact-lang/compiler": "^1.2.0",
+        "@tact-lang/compiler": "^1.3.0",
         "@ton-community/func-js": "^0.7.0",
         "@tonconnect/sdk": "^2.2.0",
         "arg": "^5.0.2",

--- a/src/build.ts
+++ b/src/build.ts
@@ -25,6 +25,11 @@ export async function buildOne(contract: string, ui?: UIProvider) {
                 });
                 await fs.writeFile(k, v);
             }
+
+            if (result.options !== undefined && result.options?.debug === true) {
+                ui?.clearActionPrompt();
+                ui?.write('\n⚠️ Make sure to disable debug mode in contract wrappers before doing production deployments!');
+            }
         }
 
         const cell = result.code;

--- a/src/build.ts
+++ b/src/build.ts
@@ -28,16 +28,18 @@ export async function buildOne(contract: string, ui?: UIProvider) {
 
             if (result.options !== undefined && result.options?.debug === true) {
                 ui?.clearActionPrompt();
-                ui?.write('\n⚠️ Make sure to disable debug mode in contract wrappers before doing production deployments!');
+                ui?.write(
+                    '\n⚠️ Make sure to disable debug mode in contract wrappers before doing production deployments!',
+                );
             }
         }
 
         const cell = result.code;
         const rHash = cell.hash();
-        const res  = {
+        const res = {
             hash: rHash.toString('hex'),
             hashBase64: rHash.toString('base64'),
-            hex: cell.toBoc().toString('hex')
+            hex: cell.toBoc().toString('hex'),
         };
         ui?.clearActionPrompt();
         ui?.write('\n✅ Compiled successfully! Cell BOC result:\n\n');
@@ -45,10 +47,7 @@ export async function buildOne(contract: string, ui?: UIProvider) {
 
         await fs.mkdir(BUILD_DIR, { recursive: true });
 
-        await fs.writeFile(
-            buildArtifactPath,
-            JSON.stringify(res)
-        );
+        await fs.writeFile(buildArtifactPath, JSON.stringify(res));
 
         ui?.write(`\n✅ Wrote compilation artifact to ${path.relative(process.cwd(), buildArtifactPath)}`);
     } catch (e) {

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -96,6 +96,7 @@ async function doCompileTact(config: TactCompilerConfig, name: string): Promise<
             path: config.target,
             output: path.join(BUILD_DIR, name),
             options: {...rootConfigOptions, ...config.options},
+            mode: "full",
         },
         stdlib: '/stdlib',
         project: fs,

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -74,13 +74,7 @@ function findTactBoc(fs: Map<string, Buffer>): Cell {
 function getRootTactConfigOptionsForContract(name: string): ConfigProject['options'] | undefined {
     if (!existsSync(TACT_ROOT_CONFIG)) { return undefined; }
 
-    // TODO: Temporary hack, see next comment.
-    const schemalessConfig = JSON.parse(readFileSync(TACT_ROOT_CONFIG).toString());
-    delete schemalessConfig.$schema;
-    const config: Config = parseConfig(JSON.stringify(schemalessConfig));
-
-    // TODO: Once Tact v1.3.0 releases, use the following line instead of the temporary hack above:
-    // const config: Config = parseConfig(readFileSync(TACT_ROOT_CONFIG)).toString();
+    const config: Config = parseConfig(readFileSync(TACT_ROOT_CONFIG).toString());
 
     for (const project of config.projects) {
         if (project.name === name) {

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -73,7 +73,9 @@ function findTactBoc(fs: Map<string, Buffer>): Cell {
 }
 
 function getRootTactConfigOptionsForContract(name: string): TactCompilerConfig['options'] | undefined {
-    if (!existsSync(TACT_ROOT_CONFIG)) { return undefined; }
+    if (!existsSync(TACT_ROOT_CONFIG)) {
+        return undefined;
+    }
 
     const config: Tact.Config = Tact.parseConfig(readFileSync(TACT_ROOT_CONFIG).toString());
 
@@ -95,8 +97,7 @@ async function doCompileTact(config: TactCompilerConfig, name: string): Promise<
             name: 'tact',
             path: config.target,
             output: path.join(BUILD_DIR, name),
-            options: {...rootConfigOptions, ...config.options},
-            mode: "full",
+            options: { ...rootConfigOptions, ...config.options },
         },
         stdlib: '/stdlib',
         project: fs,

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -13,3 +13,5 @@ export const BUILD_DIR = path.join(process.cwd(), BUILD);
 export const TEMP_DIR = path.join(process.cwd(), TEMP);
 export const CONTRACTS_DIR = path.join(process.cwd(), CONTRACTS);
 export const TESTS_DIR = path.join(process.cwd(), TESTS);
+
+export const TACT_ROOT_CONFIG = path.join(process.cwd(), 'tact.config.json');

--- a/src/templates/tact/common/wrappers/compile.ts.template
+++ b/src/templates/tact/common/wrappers/compile.ts.template
@@ -4,4 +4,7 @@ import { CompilerConfig } from '@ton/blueprint';
 export const compile: CompilerConfig = {
     lang: 'tact',
     target: '{{contractPath}}',
+    options: {
+        debug: true,
+    },
 };

--- a/src/templates/tact/empty/contracts/contract.tact.template
+++ b/src/templates/tact/empty/contracts/contract.tact.template
@@ -2,7 +2,8 @@
 import "@stdlib/deploy";
 
 contract {{name}} with Deployable {
-    init() {
-        
-    }
+    // Empty init() function is present by default in all Tact contracts
+    // since v1.3.0, so the following may be omitted:
+    //
+    // init() {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,9 +153,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tact-lang/compiler@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@tact-lang/compiler@npm:1.2.0"
+"@tact-lang/compiler@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@tact-lang/compiler@npm:1.3.0"
   dependencies:
     "@ipld/dag-pb": 2.1.18
     "@tact-lang/opcode": ^0.0.14

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,22 +159,22 @@ __metadata:
   dependencies:
     "@ipld/dag-pb": 2.1.18
     "@tact-lang/opcode": ^0.0.14
-    "@ton/core": 0.49.2
+    "@ton/core": 0.56.3
     "@ton/crypto": ^3.2.0
-    arg: ^5.0.2
     blockstore-core: 1.0.5
     change-case: ^4.1.2
     ipfs-unixfs-importer: 9.0.10
+    meow: ^13.2.0
     mkdirp: ^2.1.3
-    multiformats: 9.9.0
-    ohm-js: 16.5.0
-    path-normalize: ^6.0.10
+    multiformats: ^13.1.0
+    ohm-js: ^17.1.0
+    path-normalize: ^6.0.13
     prando: ^6.0.1
-    qs: ^6.11.0
+    qs: ^6.12.1
     zod: ^3.22.4
   bin:
     tact: bin/tact
-  checksum: 8e9a55883c9550ba0bf2585c32e1da0e5f9c1f9947a31cd4d4cbf49df4980e6fbb13ed21469fba6ea6f895ab03d86dcec1ee73a8a9a303a395c2185b927e4d5f
+  checksum: d5f1b33750f852835a63f49c41ce96186e8f00b3cc8b13a0070e46441453cca984c67c3431db0d17851c1789ad8830397e4276a6965a0754193843b7e3c4d98e
   languageName: node
   linkType: hard
 
@@ -212,7 +212,7 @@ __metadata:
   resolution: "@ton/blueprint@workspace:."
   dependencies:
     "@orbs-network/ton-access": ^2.3.3
-    "@tact-lang/compiler": ^1.2.0
+    "@tact-lang/compiler": ^1.3.0
     "@ton-community/func-js": ^0.7.0
     "@ton/core": ^0.56.0
     "@ton/crypto": ^3.2.0
@@ -239,14 +239,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ton/core@npm:0.49.2":
-  version: 0.49.2
-  resolution: "@ton/core@npm:0.49.2"
+"@ton/core@npm:0.56.3":
+  version: 0.56.3
+  resolution: "@ton/core@npm:0.56.3"
   dependencies:
     symbol.inspect: 1.0.1
   peerDependencies:
     "@ton/crypto": ">=3.2.0"
-  checksum: c0bbad44f89664852d2289e073fa5666d38b4738f13cb951b973bd56b635df6d45ee26c6d1d6348c8736172fd84aaa8f5ef3296f45cca2b346c715a92a0cf774
+  checksum: bb0d2e444b832a64933f0a98e1f681f609d90b0085f5a138f0d066e47d7c4005f288455aea8c48d669e704ea803dd8e7e3e5a07dcdeb1d7dab57e1b01126f34b
   languageName: node
   linkType: hard
 
@@ -580,13 +580,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "call-bind@npm:1.0.2"
+"call-bind@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "call-bind@npm:1.0.7"
   dependencies:
-    function-bind: ^1.1.1
-    get-intrinsic: ^1.0.2
-  checksum: f8e31de9d19988a4b80f3e704788c4a2d6b6f3d17cfec4f57dc29ced450c53a49270dc66bf0fbd693329ee948dd33e6c90a329519aef17474a4d961e8d6426b0
+    es-define-property: ^1.0.0
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+    get-intrinsic: ^1.2.4
+    set-function-length: ^1.2.1
+  checksum: 295c0c62b90dd6522e6db3b0ab1ce26bdf9e7404215bda13cfee25b626b5ff1a7761324d58d38b1ef1607fc65aca2d06e44d2e18d0dfc6c14b465b00d8660029
   languageName: node
   linkType: hard
 
@@ -749,6 +752,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-data-property@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "define-data-property@npm:1.1.4"
+  dependencies:
+    es-define-property: ^1.0.0
+    es-errors: ^1.3.0
+    gopd: ^1.0.1
+  checksum: 8068ee6cab694d409ac25936eb861eea704b7763f7f342adbdfe337fc27c78d7ae0eff2364b2917b58c508d723c7a074326d068eef2e45c4edcd85cf94d0313b
+  languageName: node
+  linkType: hard
+
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
@@ -791,6 +805,22 @@ __metadata:
   version: 3.0.1
   resolution: "err-code@npm:3.0.1"
   checksum: aede1f1d5ebe6d6b30b5e3175e3cc13e67de2e2e1ad99ce4917e957d7b59e8451ed10ee37dbc6493521920a47082c479b9097e5c39438d4aff4cc84438568a5a
+  languageName: node
+  linkType: hard
+
+"es-define-property@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-define-property@npm:1.0.0"
+  dependencies:
+    get-intrinsic: ^1.2.4
+  checksum: f66ece0a887b6dca71848fa71f70461357c0e4e7249696f81bad0a1f347eed7b31262af4a29f5d726dc026426f085483b6b90301855e647aa8e21936f07293c6
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: ec1414527a0ccacd7f15f4a3bc66e215f04f595ba23ca75cdae0927af099b5ec865f9f4d33e9d7e86f512f252876ac77d4281a7871531a50678132429b1271b5
   languageName: node
   linkType: hard
 
@@ -866,22 +896,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"function-bind@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "function-bind@npm:1.1.1"
-  checksum: b32fbaebb3f8ec4969f033073b43f5c8befbb58f1a79e12f1d7490358150359ebd92f49e72ff0144f65f2c48ea2a605bff2d07965f548f6474fd8efd95bf361a
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 2b0ff4ce708d99715ad14a6d1f894e2a83242e4a52ccfcefaee5e40050562e5f6dafc1adbb4ce2d4ab47279a45dc736ab91ea5042d843c3c092820dfe032efb1
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.0.2":
-  version: 1.2.1
-  resolution: "get-intrinsic@npm:1.2.1"
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "get-intrinsic@npm:1.2.4"
   dependencies:
-    function-bind: ^1.1.1
-    has: ^1.0.3
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
     has-proto: ^1.0.1
     has-symbols: ^1.0.3
-  checksum: 5b61d88552c24b0cf6fa2d1b3bc5459d7306f699de060d76442cce49a4721f52b8c560a33ab392cf5575b7810277d54ded9d4d39a1ea61855619ebc005aa7e5f
+    hasown: ^2.0.0
+  checksum: 414e3cdf2c203d1b9d7d33111df746a4512a1aa622770b361dadddf8ed0b5aeb26c560f49ca077e24bfafb0acb55ca908d1f709216ccba33ffc548ec8a79a951
+  languageName: node
+  linkType: hard
+
+"gopd@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "gopd@npm:1.0.1"
+  dependencies:
+    get-intrinsic: ^1.1.3
+  checksum: a5ccfb8806e0917a94e0b3de2af2ea4979c1da920bc381667c260e00e7cafdbe844e2cb9c5bcfef4e5412e8bf73bab837285bc35c7ba73aaaf0134d4583393a6
   languageName: node
   linkType: hard
 
@@ -902,6 +942,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-property-descriptors@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-property-descriptors@npm:1.0.2"
+  dependencies:
+    es-define-property: ^1.0.0
+  checksum: fcbb246ea2838058be39887935231c6d5788babed499d0e9d0cc5737494c48aba4fe17ba1449e0d0fbbb1e36175442faa37f9c427ae357d6ccb1d895fbcd3de3
+  languageName: node
+  linkType: hard
+
 "has-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "has-proto@npm:1.0.1"
@@ -916,12 +965,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "has@npm:1.0.3"
+"hasown@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
   dependencies:
-    function-bind: ^1.1.1
-  checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
+    function-bind: ^1.1.2
+  checksum: e8516f776a15149ca6c6ed2ae3110c417a00b62260e222590e54aa367cbcd6ed99122020b37b7fbdf05748df57b265e70095d7bf35a47660587619b15ffb93db
   languageName: node
   linkType: hard
 
@@ -1195,6 +1244,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"meow@npm:^13.2.0":
+  version: 13.2.0
+  resolution: "meow@npm:13.2.0"
+  checksum: 79c61dc02ad448ff5c29bbaf1ef42181f1eae9947112c0e23db93e84cbc2708ecda53e54bfc6689f1e55255b2cea26840ec76e57a5773a16ca45f4fe2163ec1c
+  languageName: node
+  linkType: hard
+
 "merge-options@npm:^3.0.4":
   version: 3.0.4
   resolution: "merge-options@npm:3.0.4"
@@ -1250,7 +1306,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multiformats@npm:9.9.0, multiformats@npm:^9.0.4, multiformats@npm:^9.4.2, multiformats@npm:^9.4.7, multiformats@npm:^9.5.4":
+"multiformats@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "multiformats@npm:13.1.0"
+  checksum: b970e3622a80192a4df8c23378c4854520df8b2d17db773ac8b77c19750019e1c9813cc05e12b0e3b0d03599ff5d073681e847d43b4b273efca5aabbb28eb0e0
+  languageName: node
+  linkType: hard
+
+"multiformats@npm:^9.0.4, multiformats@npm:^9.4.2, multiformats@npm:^9.4.7, multiformats@npm:^9.5.4":
   version: 9.9.0
   resolution: "multiformats@npm:9.9.0"
   checksum: d3e8c1be400c09a014f557ea02251a2710dbc9fca5aa32cc702ff29f636c5471e17979f30bdcb0a9cbb556f162a8591dc2e1219c24fc21394a56115b820bb84e
@@ -1305,17 +1368,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.9.0":
-  version: 1.12.3
-  resolution: "object-inspect@npm:1.12.3"
-  checksum: dabfd824d97a5f407e6d5d24810d888859f6be394d8b733a77442b277e0808860555176719c5905e765e3743a7cada6b8b0a3b85e5331c530fd418cc8ae991db
+"object-inspect@npm:^1.13.1":
+  version: 1.13.1
+  resolution: "object-inspect@npm:1.13.1"
+  checksum: 7d9fa9221de3311dcb5c7c307ee5dc011cdd31dc43624b7c184b3840514e118e05ef0002be5388304c416c0eb592feb46e983db12577fc47e47d5752fbbfb61f
   languageName: node
   linkType: hard
 
-"ohm-js@npm:16.5.0":
-  version: 16.5.0
-  resolution: "ohm-js@npm:16.5.0"
-  checksum: 0fd220fc3619311f9cb86dc2848ecc733aeec10d124a15a0966f8b1b61e85352e7bff58e3d5b9f30ed014aa34ac293cefb775f2b3e5bd99ce757ffead312a045
+"ohm-js@npm:^17.1.0":
+  version: 17.1.0
+  resolution: "ohm-js@npm:17.1.0"
+  checksum: de26f1d1f598a06a3cdd99d1a995350186c52709b2b1e96d58b6f1f88f30d4784ce6ee49939f50333e21ffe31be306c0a644d373af840c1deebe0f10aad3c98e
   languageName: node
   linkType: hard
 
@@ -1382,10 +1445,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-normalize@npm:^6.0.10":
-  version: 6.0.12
-  resolution: "path-normalize@npm:6.0.12"
-  checksum: 9c8b7130ff4c673308395806b0313b2746349cca21e9885cbfe598ab3d90b41c79193cca89659826c7a1001e771db6d6fc222ea1c8349122e9915274614668e8
+"path-normalize@npm:^6.0.13":
+  version: 6.0.13
+  resolution: "path-normalize@npm:6.0.13"
+  checksum: fe3d6264c10ee67ce99b257564dc986bedf746ed579b57271843906ccaa9c3fdf98b6e048b77701ac7c784ff3e46b39a972202f15857eb4668d98c6be53d3e7c
   languageName: node
   linkType: hard
 
@@ -1438,12 +1501,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.11.0":
-  version: 6.11.2
-  resolution: "qs@npm:6.11.2"
+"qs@npm:^6.12.1":
+  version: 6.12.1
+  resolution: "qs@npm:6.12.1"
   dependencies:
-    side-channel: ^1.0.4
-  checksum: e812f3c590b2262548647d62f1637b6989cc56656dc960b893fe2098d96e1bd633f36576f4cd7564dfbff9db42e17775884db96d846bebe4f37420d073ecdc0b
+    side-channel: ^1.0.6
+  checksum: aa761d99e65b6936ba2dd2187f2d9976afbcda38deb3ff1b3fe331d09b0c578ed79ca2abdde1271164b5be619c521ec7db9b34c23f49a074e5921372d16242d5
   languageName: node
   linkType: hard
 
@@ -1525,14 +1588,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "side-channel@npm:1.0.4"
+"set-function-length@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "set-function-length@npm:1.2.2"
   dependencies:
-    call-bind: ^1.0.0
-    get-intrinsic: ^1.0.2
-    object-inspect: ^1.9.0
-  checksum: 351e41b947079c10bd0858364f32bb3a7379514c399edb64ab3dce683933483fc63fb5e4efe0a15a2e8a7e3c436b6a91736ddb8d8c6591b0460a24bb4a1ee245
+    define-data-property: ^1.1.4
+    es-errors: ^1.3.0
+    function-bind: ^1.1.2
+    get-intrinsic: ^1.2.4
+    gopd: ^1.0.1
+    has-property-descriptors: ^1.0.2
+  checksum: a8248bdacdf84cb0fab4637774d9fb3c7a8e6089866d04c817583ff48e14149c87044ce683d7f50759a8c50fb87c7a7e173535b06169c87ef76f5fb276dfff72
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "side-channel@npm:1.0.6"
+  dependencies:
+    call-bind: ^1.0.7
+    es-errors: ^1.3.0
+    get-intrinsic: ^1.2.4
+    object-inspect: ^1.13.1
+  checksum: bfc1afc1827d712271453e91b7cd3878ac0efd767495fd4e594c4c2afaa7963b7b510e249572bfd54b0527e66e4a12b61b80c061389e129755f34c493aad9b97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #94

Additionally, bumped the Tact version to 1.3.0. This will be marked as "Ready for review" upon the release of Tact 1.3.0.