### PR TITLE
feat: make receiver in Tact template refund remaining value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Changed `contract.tact.template` counter template to return remaining value from the message
+
 ## [0.20.0] - 2024-05-07
 
 ### Added

--- a/src/templates/tact/counter/contracts/contract.tact.template
+++ b/src/templates/tact/counter/contracts/contract.tact.template
@@ -17,6 +17,9 @@ contract {{name}} with Deployable {
 
     receive(msg: Add) {
         self.counter += msg.amount;
+
+        // Notify the caller that the receiver was executed and forward remaining value back
+        self.notify("Cashback".asComment());
     }
 
     get fun counter(): Int {


### PR DESCRIPTION
Deploy returns excessive funds when the user uses `@stdlib/deploy` and `Deployable` trait. Therefore, it would be nice to showcase how to do the same in `receive()` functions right in the counter template.

Related links:
* https://github.com/tact-lang/tact-docs/issues/231
* https://github.com/tact-lang/tact-docs/pull/232