### PR TITLE
fix: stop calling build() in legacy way

### DIFF
--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -145,7 +145,7 @@ async function doCompileTact(config: TactCompilerConfig, name: string): Promise<
             output: path.join(BUILD_DIR, name),
             options: { ...rootConfigOptions, ...config.options },
         },
-        stdlib: '/stdlib',
+        stdlib: Tact.createVirtualFileSystem("@stdlib", Tact.stdLibFiles),
         project: fs,
     };
 


### PR DESCRIPTION
Calling `build()` with a file system name instead of the file system itself is deprecated.

This PR creates virtual file system for standard library at call site, as expected.