### PR TITLE
Change jest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
         "@types/node": "^20.2.5",
         "@types/qrcode-terminal": "^0.12.0",
         "eslint": "^9.28.0",
-        "jest": "^30.0.0",
-        "ts-jest": "^29.3.4",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.4.0",
         "typescript": "^5.8.3"
     },
     "peerDependencies": {


### PR DESCRIPTION
We've previously bumped jest to `30.0.0`, although it seems that `ts-jest` isn't ready for that yet, and it feels like avoiding versioning conflicts is the best course of action.