### PR TITLE
feat: compile into library

### DIFF
--- a/src/compile/CompilerConfig.ts
+++ b/src/compile/CompilerConfig.ts
@@ -37,6 +37,13 @@ export type CommonCompilerConfig = {
      * };
      */
     postCompileHook?: (code: Cell, params: HookParams) => Promise<void>;
+
+    /**
+     * Allows to build artifact into library cell instead of regular
+     * code cell
+     * https://docs.ton.org/v3/documentation/data-formats/tlb/library-cells#introduction
+     */
+    buildLibrary?: boolean;
 };
 
 export type CompilableConfig = (TactLegacyCompilerConfig | FuncCompilerConfig | TolkCompilerConfig) &

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -155,8 +155,8 @@ export async function doCompile(name: string, opts?: CompileOpts): Promise<Compi
 
     if (buildLibrary) {
         // Pack resulting code hash into library cell
-        const lib_prep = beginCell().storeUint(2, 8).storeBuffer(res.code.hash()).endCell();
-        res.code = new Cell({ exotic: true, bits: lib_prep.bits, refs: lib_prep.refs });
+        const libPrep = beginCell().storeUint(2, 8).storeBuffer(res.code.hash()).endCell();
+        res.code = new Cell({ exotic: true, bits: libPrep.bits, refs: libPrep.refs });
     }
 
     return res;

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import path from 'path';
 
-import { Cell } from '@ton/core';
+import { beginCell, Cell } from '@ton/core';
 
 import { COMPILABLES_DIR, WRAPPERS_DIR } from '../paths';
 import { CompilableConfig, CompilerConfig, isCompilableConfig } from './CompilerConfig';
@@ -149,6 +149,12 @@ export async function doCompile(name: string, opts?: CompileOpts): Promise<Compi
         await config.postCompileHook(res.code, {
             userData: opts?.hookUserData,
         });
+    }
+
+    if ('buildLibrary' in config && config.buildLibrary === true) {
+        // Pack resulting code hash into library cell
+        const lib_prep = beginCell().storeUint(2, 8).storeBuffer(res.code.hash()).endCell();
+        res.code = new Cell({ exotic: true, bits: lib_prep.bits, refs: lib_prep.refs });
     }
 
     return res;

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -151,7 +151,9 @@ export async function doCompile(name: string, opts?: CompileOpts): Promise<Compi
         });
     }
 
-    if ('buildLibrary' in config && config.buildLibrary === true) {
+    const buildLibrary = opts?.buildLibrary ?? ('buildLibrary' in config && config.buildLibrary === true);
+
+    if (buildLibrary) {
         // Pack resulting code hash into library cell
         const lib_prep = beginCell().storeUint(2, 8).storeBuffer(res.code.hash()).endCell();
         res.code = new Cell({ exotic: true, bits: lib_prep.bits, refs: lib_prep.refs });
@@ -169,6 +171,7 @@ export type CompileOpts = {
      */
     hookUserData?: any;
     debugInfo?: boolean;
+    buildLibrary?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Checklist

Please ensure the following items are completed before requesting review:

* [ ] Updated `CHANGELOG.md` with relevant changes
* [ ] Documented the contribution in `README.md`
* [ ] Added tests to demonstrate correct behavior (both positive and negative cases)
* [x] All tests pass successfully (`yarn test`)
* [x] Code passes linting checks (`yarn lint`)

## Build library

Idea behind this PR is to add blag to the CompilerConfig
that enables the contract to be build straight into library.

Before, one would have to do something like:
``` typescript
        jwallet_code_raw   = await compile('JettonWallet');
        let lib_prep = beginCell().storeUint(2,8).storeBuffer(jwallet_code_raw.hash()).endCell();
        jwallet_code = new Cell({ exotic:true, bits: lib_prep.bits, refs:lib_prep.refs });
        jettonMinter   = blockchain.openContract(
        JettonMinter.createFromConfig({
                         wallet_code: jwallet_code,
                         ....
                       },
                       minter_code));


```

After the change, one would be able to use `CompilerConfig` wrapper like:
``` typescript
 import { CompilerConfig } from '@ton/blueprint';
      
  export const compile: CompilerConfig = {
      targets: ['contracts/jetton-wallet.fc'],
      buildLibrary: true
  };  
```
and do just this:
``` typescript
jwallet_code = await compile('JettonWallet');
```

### Why this is important?

Reason is that people often overlook this nuance of deployment
in setups where library is necessary, resulting into gas and message overhead
mismatch between what was measured in tests, and actual deployment.

In case library artifact is produced at the compile wrapper level, and user copies it as is without any further considerations, they would at least face execution issues due to lack of library in the network, rather than running on the invalid setup.

### Drawbacks

In case one needs both raw code and lib artifact, they would
have to use two `CompilerConfig` wrappers to achieve that.

Which is not a terrible thing, but perhaps it worth adding the flag to [CompileOpts(https://github.com/ton-org/blueprint/blob/1b5b5b19cc37a428f96688cdde5e35b5003b54cc/src/compile/compile.ts#L160)
in order to override `buildLibrary` flag if necessary?

For example like this:
``` typescript
 import { CompilerConfig } from '@ton/blueprint';
      
  export const compile: CompilerConfig = {
      targets: ['contracts/jetton-wallet.fc'],
      buildLibrary: true
  };  
```

And then:
``` typescript
const jwallet_code_raw = await compile('JettonWallet', {buildLibrary: false});
```