### PR TITLE
chore: removed mention of the `func-vscode` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Blueprint is an all-in-one development environment designed to enhance the proce
 
 * [Node.js](https://nodejs.org) with a recent version like v18. Version can be verified with `node -v`
 * IDE with TON support:
-  * [Visual Studio Code](https://code.visualstudio.com/) with the [TON plugin](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton), [FunC plugin](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode), or [Tact plugin](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact)
+  * [Visual Studio Code](https://code.visualstudio.com/) with the [TON plugin](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton) or [Tact plugin](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact)
   * [IntelliJ IDEA](https://www.jetbrains.com/idea/)
     * [TON Development plugin](https://plugins.jetbrains.com/plugin/23382-ton) for Tolk, FunC and Fift
     * [Tact plugin by TON Studio](https://plugins.jetbrains.com/plugin/27290-tact) for Tact


### PR DESCRIPTION
## Issue

The [`FunC plugin`](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode) extension is deprecated, all of its functions have been replaced by the [`TON plugin`](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton) extension.

See: https://github.com/ton-community/vscode-func/pull/19 and https://github.com/ton-blockchain/ton-language-server/issues/167

## Checklist

Please ensure the following items are completed before requesting review:

* [ ] Updated `CHANGELOG.md` with relevant changes
* [x] Documented the contribution in `README.md`
* [x] Added tests to demonstrate correct behavior (both positive and negative cases)
* [x] All tests pass successfully (`yarn test`)
* [x] Code passes linting checks (`yarn lint`)
